### PR TITLE
Include the entire __pycache__ folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ VK4Tehtävä
 VK5Tehtävä
 
 # artifakteja joita Python joskus tekee
-__pycache__
-*/__pycache__
+*__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
+# jotain meiän projektille ominaista kamaa
 mygame.zip
 mygame2.zip
-__pycache__/temp.cpython-38.pyc
-modules/__pycache__/temp.cpython-38.pyc
 VK4Tehtävä
 VK5Tehtävä
+
+# artifakteja joita Python joskus tekee
+__pycache__
+*/__pycache__


### PR DESCRIPTION
Gitignoring specific files from inside any one person's __pycache__ just isn't efficient. Different versions of Python generate different file names, and none of the files in __pycache__ need to be shared, so gitignoring the entire folder is a much better option.